### PR TITLE
Add run_deployment timeout

### DIFF
--- a/nslsii_kafka/consumer/prefect_consumer.py
+++ b/nslsii_kafka/consumer/prefect_consumer.py
@@ -61,6 +61,7 @@ def message_to_workflow():
                 run_deployment(
                     name=args.deployment_name,
                     parameters={"stop_doc": doc},
+                    timeout=30
                 )
             else:
                 print(doc_name)

--- a/nslsii_kafka/consumer/prefect_consumer.py
+++ b/nslsii_kafka/consumer/prefect_consumer.py
@@ -61,7 +61,7 @@ def message_to_workflow():
                 run_deployment(
                     name=args.deployment_name,
                     parameters={"stop_doc": doc},
-                    timeout=30
+                    timeout=180
                 )
             else:
                 print(doc_name)

--- a/nslsii_kafka/consumer/prefect_consumer.py
+++ b/nslsii_kafka/consumer/prefect_consumer.py
@@ -61,7 +61,7 @@ def message_to_workflow():
                 run_deployment(
                     name=args.deployment_name,
                     parameters={"stop_doc": doc},
-                    timeout=180
+                    timeout=180,
                 )
             else:
                 print(doc_name)


### PR DESCRIPTION
This is to fix the issue where the prefect kafka consumer leaves the kafka group after timing out waiting for a deployment to complete.